### PR TITLE
MacOS: Fix memory leaks

### DIFF
--- a/src/keyring/macos.nim
+++ b/src/keyring/macos.nim
@@ -24,10 +24,15 @@ proc setPassword*(service: string, username: string, password: string) =
     k_password = kSecValueData
     v_password = mkCFData(password.encode())
 
+  defer: CFRelease(v_service)
+  defer: CFRelease(v_account)
+  defer: CFRelease(v_password)
+
   var ikeys:array[4,CFStringRef] = [key1, k_service, k_account, k_password]
   var ivals:array[4,CFTypeRef] = [val1, v_service, v_account, v_password]
   let ilen:CFIndex = ikeys.len.CFIndex
   let item = CFDictionaryCreate(nil, ikeys.addr, ivals.addr, ilen, nil, nil)
+  defer: CFRelease(item)
 
   var err = SecItemAdd(item, nil)
   if err == errSecDuplicateItem:
@@ -36,11 +41,13 @@ proc setPassword*(service: string, username: string, password: string) =
     var qvals:array[5, CFTypeRef]   = [val1, v_service, v_account, kSecMatchLimitOne, kCFBooleanFalse]
     let qlen:CFIndex = qkeys.len.CFIndex
     let query = CFDictionaryCreate(nil, qkeys.addr, qvals.addr, qlen, nil, nil)
+    defer: CFRelease(query)
 
     var pkeys:array[2, CFStringRef] = [key1, k_password]
     var pvals:array[2, CFTypeRef] = [val1, v_password]
     let plen:CFIndex = pkeys.len.CFIndex
     let patch = CFDictionaryCreate(nil, pkeys.addr, pvals.addr, plen, nil, nil)
+    defer: CFRelease(patch)
 
     err = SecItemUpdate(query, patch)
   
@@ -58,18 +65,23 @@ proc getPassword*(service: string, username: string): Option[string] =
     # account
     k_account = kSecAttrAccount
     v_account = mkCFString(username)
+
+  defer: CFRelease(v_service)
+  defer: CFRelease(v_account)
   
   var qkeys:array[5, CFStringRef] = [key1, k_service, k_account, kSecMatchLimit,    kSecReturnData]
   var qvals:array[5, CFTypeRef] =   [val1, v_service, v_account, kSecMatchLimitOne, kCFBooleanTrue]
   let qlen:CFIndex = qkeys.len.CFIndex
   let query = CFDictionaryCreate(nil, qkeys.addr, qvals.addr, qlen, nil, nil)
+  defer: CFRelease(query)
   
-  var password = mkCFData("")
+  var password: CFDataRef
   let err = SecItemCopyMatching(query, cast[ptr CFTypeRef](password.addr))
   if err == errSecSuccess:
-    return some(($password).decode())
+    result = some(($password).decode())
+    CFRelease(password)
   else:
-    return none[string]()
+    result = none[string]()
 
 proc deletePassword*(service: string, username: string) =
   ## Delete a saved password (if it exists)
@@ -82,11 +94,15 @@ proc deletePassword*(service: string, username: string) =
     # account
     k_account = kSecAttrAccount
     v_account = mkCFString(username)
+
+  defer: CFRelease(v_service)
+  defer: CFRelease(v_account)
   
   var qkeys:array[4, CFStringRef] = [key1, k_service, k_account, kSecMatchLimit]
   var qvals:array[4, CFStringRef] = [val1, v_service, v_account, kSecMatchLimitOne]
   let qlen:CFIndex = qkeys.len.CFIndex
   let query = CFDictionaryCreate(nil, qkeys.addr, qvals.addr, qlen, nil, nil)
+  defer: CFRelease(query)
 
   let err = SecItemDelete(query)
   if err == errSecItemNotFound:

--- a/src/keyring/macos_keyringapi.nim
+++ b/src/keyring/macos_keyringapi.nim
@@ -31,6 +31,7 @@ type
   CFBooleanRef* = ptr object of CFTypeRef
 
 # Types
+proc CFRelease*(cf: CFTypeRef) {.importc.}
 proc CFGetTypeID*(cf: CFTypeRef): CFTypeID {.importc.}
 proc CFBooleanGetTypeID*(): CFTypeID {.importc.}
 proc CFDataGetTypeID*(): CFTypeID {.importc.}

--- a/tests/tmac.nim
+++ b/tests/tmac.nim
@@ -6,6 +6,7 @@ when defined(macosx):
   test "CFString roundtrip":
     let orig = "hello world!"
     let cf = mkCFString(orig)
+    defer: CFRelease(cf)
     let res = $cf
     check res == orig
     check res.len == orig.len
@@ -13,6 +14,7 @@ when defined(macosx):
   test "CFData roundtrip":
     let orig = "hello world!"
     let cf = mkCFData(orig)
+    defer: CFRelease(cf)
     let res = $cf
     check res == orig
     check res.len == orig.len


### PR DESCRIPTION
Release CoreFoundation objects when they're no longer needed.